### PR TITLE
Replaces '-' on non-printable with unicode replacement character '�'

### DIFF
--- a/freq.go
+++ b/freq.go
@@ -114,9 +114,9 @@ func readRunes(file string, f *os.File) {
 
 func print() {
 	if countBytes {
-		printCounts("%.2x %c\t%d\n", "%.2x -\t%d\n")
+		printCounts("%.2x %c\t%d\n", "%.2x �\t%d\n")
 	} else {
-		printCounts("%.4x %c\t%d\n", "%.4x -\t%d\n")
+		printCounts("%.4x %c\t%d\n", "%.4x �\t%d\n")
 	}
 }
 


### PR DESCRIPTION
I was confused why I had so many different hyphen characters in my code.  I actually looked up the code points before I realized that hyphen was the non-printable display character.

I think it would be clearer to use � the unicode replacement character than a hyphen to represent non-printables.
### old

<img width="548" alt="screen shot 2015-12-01 at 8 18 00 pm" src="https://cloud.githubusercontent.com/assets/133747/11520422/e5d40b66-9868-11e5-8bdc-dc57d4c49299.png">
### new

<img width="544" alt="screen shot 2015-12-01 at 8 18 39 pm" src="https://cloud.githubusercontent.com/assets/133747/11520430/ef89b246-9868-11e5-9d97-e421419d264c.png">
